### PR TITLE
Potential fix for code scanning alert no. 13: Unvalidated dynamic method call

### DIFF
--- a/revealjs/plugin/notes/speaker-view.html
+++ b/revealjs/plugin/notes/speaker-view.html
@@ -345,7 +345,7 @@
 					upcomingSlide,
 					layoutLabel,
 					layoutDropdown,
-					pendingCalls = {},
+					pendingCalls = Object.create( null ),
 					lastRevealApiCallId = 0,
 					connected = false;
 

--- a/revealjs/plugin/notes/speaker-view.html
+++ b/revealjs/plugin/notes/speaker-view.html
@@ -383,8 +383,11 @@
 							handleStateMessage( data );
 						}
 						else if( data.type === 'return' ) {
-							pendingCalls[data.callId](data.result);
-							delete pendingCalls[data.callId];
+							var callback = pendingCalls[data.callId];
+							if( Object.prototype.hasOwnProperty.call( pendingCalls, data.callId ) && typeof callback === 'function' ) {
+								callback( data.result );
+								delete pendingCalls[data.callId];
+							}
 						}
 					}
 					// Messages sent by the reveal.js inside of the current slide preview


### PR DESCRIPTION
Potential fix for [https://github.com/tracychui/tracychui.github.io/security/code-scanning/13](https://github.com/tracychui/tracychui.github.io/security/code-scanning/13)

To fix this without changing intended behavior, validate the dynamic lookup before invocation:

1. Ensure the `callId` key exists as an **own property** of `pendingCalls`.
2. Ensure the resolved value is a **function** before calling it.
3. Only then invoke and delete it.

Best change location: in `revealjs/plugin/notes/speaker-view.html`, inside the `else if( data.type === 'return' )` block around lines 385–388.  
Implementation detail: use `Object.prototype.hasOwnProperty.call(pendingCalls, data.callId)` plus `typeof callback === 'function'` to prevent inherited/prototype surprises and non-callable invocation errors.

No new imports or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
