### PR TITLE
Potential fix for code scanning alert no. 9: DOM text reinterpreted as HTML

### DIFF
--- a/revealjs/js/controllers/slidecontent.js
+++ b/revealjs/js/controllers/slidecontent.js
@@ -128,7 +128,9 @@ export default class SlideContent {
 
 					// Support comma separated lists of video sources
 					backgroundVideo.split( ',' ).forEach( source => {
-						video.innerHTML += '<source src="'+ source +'">';
+						const sourceElement = document.createElement( 'source' );
+						sourceElement.setAttribute( 'src', source.trim() );
+						video.appendChild( sourceElement );
 					} );
 
 					backgroundContent.appendChild( video );

--- a/revealjs/js/controllers/slidecontent.js
+++ b/revealjs/js/controllers/slidecontent.js
@@ -39,6 +39,33 @@ export default class SlideContent {
 	}
 
 	/**
+	 * Sanitizes media URLs used in src attributes.
+	 * Allows http(s) and relative URLs, blocks unsafe protocols.
+	 *
+	 * @param {string} url
+	 * @returns {string|null}
+	 */
+	sanitizeMediaUrl( url ) {
+
+		if( typeof url !== 'string' ) return null;
+
+		const trimmedUrl = url.trim();
+		if( !trimmedUrl ) return null;
+
+		try {
+			const parsedUrl = new URL( trimmedUrl, window.location.href );
+			if( parsedUrl.protocol === 'http:' || parsedUrl.protocol === 'https:' ) {
+				return parsedUrl.toString();
+			}
+		}
+		catch( e ) {
+			return null;
+		}
+
+		return null;
+	}
+
+	/**
 	 * Called when the given slide is within the configured view
 	 * distance. Shows the slide element and loads any content
 	 * that is set to load lazily (data-src).
@@ -128,9 +155,12 @@ export default class SlideContent {
 
 					// Support comma separated lists of video sources
 					backgroundVideo.split( ',' ).forEach( source => {
-						const sourceElement = document.createElement( 'source' );
-						sourceElement.setAttribute( 'src', source.trim() );
-						video.appendChild( sourceElement );
+						const sanitizedSource = this.sanitizeMediaUrl( source );
+						if( sanitizedSource ) {
+							const sourceElement = document.createElement( 'source' );
+							sourceElement.setAttribute( 'src', sanitizedSource );
+							video.appendChild( sourceElement );
+						}
 					} );
 
 					backgroundContent.appendChild( video );


### PR DESCRIPTION
Potential fix for [https://github.com/tracychui/tracychui.github.io/security/code-scanning/9](https://github.com/tracychui/tracychui.github.io/security/code-scanning/9)

General fix: do not inject untrusted values through `innerHTML`. Build DOM nodes with safe APIs (`document.createElement`) and assign untrusted strings via attributes/properties (e.g., `setAttribute('src', ...)` or `src`), optionally trimming/validating values.

Best fix here (without changing behavior): in `revealjs/js/controllers/slidecontent.js`, replace the `video.innerHTML += '<source src="'+ source +'">'` loop with creation of `<source>` elements via DOM methods:
- Split `backgroundVideo` as today.
- For each `source`, create `const sourceElement = document.createElement('source')`.
- Set `sourceElement.setAttribute('src', source.trim())` (trim to preserve expected comma-separated behavior while avoiding accidental whitespace issues).
- Append using `video.appendChild(sourceElement)`.

This preserves support for comma-separated source lists and avoids interpreting attacker-controlled text as HTML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
