### PR TITLE
Potential fix for code scanning alert no. 11: Client-side URL redirect

### DIFF
--- a/revealjs/plugin/notes/speaker-view.html
+++ b/revealjs/plugin/notes/speaker-view.html
@@ -365,10 +365,20 @@
 
 				window.addEventListener( 'message', function( event ) {
 
+					if( event.source !== window.opener || event.origin !== window.location.origin ) {
+						return;
+					}
+
 					clearTimeout( connectionTimeout );
 					connectionStatus.style.display = 'none';
 
-					var data = JSON.parse( event.data );
+					var data;
+					try {
+						data = JSON.parse( event.data );
+					}
+					catch( e ) {
+						return;
+					}
 
 					// The overview mode is only useful to the reveal.js instance
 					// where navigation occurs so we don't sync it
@@ -498,6 +508,19 @@
 				 */
 				function setupIframes( data ) {
 
+					var parsedUrl;
+					try {
+						parsedUrl = new URL( data.url, window.location.href );
+					}
+					catch( e ) {
+						return;
+					}
+
+					if( parsedUrl.origin !== window.location.origin ) {
+						return;
+					}
+
+					var safeBaseUrl = parsedUrl.href;
 					var params = [
 						'receiver',
 						'progress=false',
@@ -507,10 +530,10 @@
 						'backgroundTransition=none'
 					].join( '&' );
 
-					var urlSeparator = /\?/.test(data.url) ? '&' : '?';
+					var urlSeparator = /\?/.test( safeBaseUrl ) ? '&' : '?';
 					var hash = '#/' + data.state.indexh + '/' + data.state.indexv;
-					var currentURL = data.url + urlSeparator + params + '&postMessageEvents=true' + hash;
-					var upcomingURL = data.url + urlSeparator + params + '&controls=false' + hash;
+					var currentURL = safeBaseUrl + urlSeparator + params + '&postMessageEvents=true' + hash;
+					var upcomingURL = safeBaseUrl + urlSeparator + params + '&controls=false' + hash;
 
 					currentSlide = document.createElement( 'iframe' );
 					currentSlide.setAttribute( 'width', 1280 );


### PR DESCRIPTION
Potential fix for [https://github.com/tracychui/tracychui.github.io/security/code-scanning/11](https://github.com/tracychui/tracychui.github.io/security/code-scanning/11)

General fix: only accept `postMessage` data from the expected sender/origin, and never use untrusted URLs directly. Parse and validate URLs with the built-in `URL` API, then enforce same-origin (or a strict allowlist) before assigning to iframe `src`.

Best minimal fix in this file:
1. In the `message` event handler, reject messages unless `event.source === window.opener` and `event.origin === window.location.origin`.
2. Safely parse JSON with `try/catch` to avoid malformed-message crashes.
3. In `setupIframes(data)`, validate `data.url` by constructing `new URL(data.url, window.location.href)` and ensure `url.origin === window.location.origin`. If invalid, abort setup.
4. Use the sanitized URL string when constructing `currentURL`/`upcomingURL`.

This preserves existing functionality for normal same-origin speaker notes usage while blocking attacker-controlled cross-origin URL injection.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
