### PR TITLE
Potential fix for code scanning alert no. 8: DOM text reinterpreted as HTML

### DIFF
--- a/revealjs/js/controllers/slidecontent.js
+++ b/revealjs/js/controllers/slidecontent.js
@@ -91,10 +91,13 @@ export default class SlideContent {
 			let sources = 0;
 
 			queryAll( media, 'source[data-src]' ).forEach( source => {
-				source.setAttribute( 'src', source.getAttribute( 'data-src' ) );
+				const sanitizedSrc = this.sanitizeMediaUrl( source.getAttribute( 'data-src' ) );
+				if( sanitizedSrc ) {
+					source.setAttribute( 'src', sanitizedSrc );
+					source.setAttribute( 'data-lazy-loaded', '' );
+					sources += 1;
+				}
 				source.removeAttribute( 'data-src' );
-				source.setAttribute( 'data-lazy-loaded', '' );
-				sources += 1;
 			} );
 
 			// Enable inline video playback in mobile Safari


### PR DESCRIPTION
Potential fix for [https://github.com/tracychui/tracychui.github.io/security/code-scanning/8](https://github.com/tracychui/tracychui.github.io/security/code-scanning/8)

General fix: validate and normalize any DOM-derived URL before assigning it to URL-bearing attributes (`src`), and skip assignment when invalid.

Best fix here (without changing intended functionality): in `revealjs/js/controllers/slidecontent.js`, update the `<source[data-src]>` loading block in `load()` so it sanitizes `data-src` using the existing `sanitizeMediaUrl()` method before setting `src`. If sanitized URL is invalid (`null`), do not set `src`; still remove `data-src` and mark lazy-loaded only when assignment succeeds. This reuses existing class logic and avoids new dependencies/imports.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
