### PR TITLE
Potential fix for code scanning alert no. 6: DOM text reinterpreted as HTML

### DIFF
--- a/revealjs/js/controllers/print.js
+++ b/revealjs/js/controllers/print.js
@@ -121,7 +121,7 @@ export default class Print {
 					let numberElement = document.createElement( 'div' );
 					numberElement.classList.add( 'slide-number' );
 					numberElement.classList.add( 'slide-number-pdf' );
-					numberElement.innerHTML = slide.getAttribute( 'data-slide-number' );
+					numberElement.textContent = slide.getAttribute( 'data-slide-number' );
 					page.appendChild( numberElement );
 				}
 


### PR DESCRIPTION
Potential fix for [https://github.com/tracychui/tracychui.github.io/security/code-scanning/6](https://github.com/tracychui/tracychui.github.io/security/code-scanning/6)

Use text insertion instead of HTML insertion for the slide number.

- **General fix**: replace `innerHTML` with `textContent` (or `innerText`) when inserting data that should be treated as plain text.
- **Best fix here**: in `revealjs/js/controllers/print.js`, change the assignment on line 124 so the value from `data-slide-number` is assigned to `numberElement.textContent`. This preserves visible output while preventing parsing as HTML.
- **Scope**: single-line code change in the slide-number injection block; no new imports, helpers, or dependencies required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
