### PR TITLE
Potential fix for code scanning alert no. 7: DOM text reinterpreted as HTML

### DIFF
--- a/revealjs/js/controllers/slidecontent.js
+++ b/revealjs/js/controllers/slidecontent.js
@@ -80,8 +80,11 @@ export default class SlideContent {
 		// Media elements with data-src attributes
 		queryAll( slide, 'img[data-src], video[data-src], audio[data-src], iframe[data-src]' ).forEach( element => {
 			if( element.tagName !== 'IFRAME' || this.shouldPreload( element ) ) {
-				element.setAttribute( 'src', element.getAttribute( 'data-src' ) );
-				element.setAttribute( 'data-lazy-loaded', '' );
+				const sanitizedSrc = this.sanitizeMediaUrl( element.getAttribute( 'data-src' ) );
+				if( sanitizedSrc ) {
+					element.setAttribute( 'src', sanitizedSrc );
+					element.setAttribute( 'data-lazy-loaded', '' );
+				}
 				element.removeAttribute( 'data-src' );
 			}
 		} );


### PR DESCRIPTION
Potential fix for [https://github.com/tracychui/tracychui.github.io/security/code-scanning/7](https://github.com/tracychui/tracychui.github.io/security/code-scanning/7)

General fix: validate and sanitize all URL-like values read from DOM attributes before assigning them to `src` (or similar resource attributes), and skip assignment when invalid.

Best fix here (without changing intended behavior): in `revealjs/js/controllers/slidecontent.js`, update the lazy-load block for `img/video/audio/iframe[data-src]` so it uses `this.sanitizeMediaUrl(...)` before calling `setAttribute('src', ...)`. Only mark as lazy-loaded and remove `data-src` when a sanitized URL is accepted, or remove `data-src` regardless if you want to avoid repeated unsafe retries. To preserve existing flow and avoid stale unsafe values, remove `data-src` in all cases, but only set `src`/`data-lazy-loaded` when sanitization succeeds.

No new imports or dependencies are required because `sanitizeMediaUrl` is already defined in the same class.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
